### PR TITLE
Update to be compatible with Connect 3.x

### DIFF
--- a/lib/mpd.js
+++ b/lib/mpd.js
@@ -17,6 +17,7 @@
 var http = require('http');
 var fs = require('fs');
 var connect = require('connect');
+var serveStatic = require('serve-static');
 var zazloptimizer = require('zazloptimizer');
 var mpdhandler = require("./mpdhandler");
 
@@ -34,8 +35,8 @@ var mpdHandler = mpdhandler(mpdhost, mpdport);
 var app = connect()
 	.use("/_javascript", optimizer)
 	.use("/music", mpdHandler)
-	.use(connect.static(resourcecdir))
-	.use(connect.static(zazloptimizer.getLoaderDir()));
+	.use(serveStatic(resourcecdir))
+	.use(serveStatic(zazloptimizer.getLoaderDir()));
 
 var server = http.createServer(app).listen(port);
 mpdHandler.startWebSocketServer(server);

--- a/package.json
+++ b/package.json
@@ -1,23 +1,24 @@
-{ 
-	"name" : "mpdjs",
-	"version" : "0.1.0",
-	"description" : "Music Player Daemon client written in javascript",
-	"repository" : "git@github.com:rbackhouse/mpdjs.git",
-	"author" : "Richard Backhouse <richardabackhouse@gmail.com>",
-	"main" : "index",
-	"dependencies" : {
-		"connect" : ">= 2.0.0",
-		"zazloptimizer" : ">= 0.5.2",
-		"ws" : ">= 0.4"
-	},
-	"config" : {
-		"port" : 8080,
-		"mpdport" : 6600
-	},
-	"engine": {
-    	"node": ">=0.8"
-	},
-    "readme": "",
-    "readmeFilename": "README.md",
-    "license": "MIT"
+{
+  "name": "mpdjs",
+  "version": "0.1.0",
+  "description": "Music Player Daemon client written in javascript",
+  "repository": "git@github.com:rbackhouse/mpdjs.git",
+  "author": "Richard Backhouse <richardabackhouse@gmail.com>",
+  "main": "index",
+  "dependencies": {
+    "connect": ">= 2.0.0",
+    "serve-static": "^1.6.1",
+    "ws": ">= 0.4",
+    "zazloptimizer": ">= 0.5.2"
+  },
+  "config": {
+    "port": 8080,
+    "mpdport": 6600
+  },
+  "engine": {
+    "node": ">=0.8"
+  },
+  "readme": "",
+  "readmeFilename": "README.md",
+  "license": "MIT"
 }


### PR DESCRIPTION
This latest version of Connect has moved the connect.static middleware
out of core.

This patch adds a dependency on the now-seperate "serve-static"
middleware and replaces the use of connect.static with that middleware
instead. This allows an install using "npm install" to actually work on
the first try--otherwise, users have to patch this. Alternate solutiosn
would be to pin the major version number in package.json to be for
connect 2.x
